### PR TITLE
Fix subscribe button by enabling jekyll-feed plugin

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ remote_theme: chrisrhymes/bulma-clean-theme@v0.14.0
 #remote_theme: just-the-docs/just-the-docs
 #theme: minima
 plugins:
-# - jekyll-feed
+ - jekyll-feed
 
 # collections
 collections:


### PR DESCRIPTION
Fixes #6

The subscribe button on the News page was pointing to a non-existent feed.xml because the jekyll-feed plugin was commented out.

## Changes
- Uncommented jekyll-feed plugin in _config.yml
- This will automatically generate feed.xml when the site builds
- Resolves the broken subscribe button

🤖 Generated with [Claude Code](https://claude.ai/code)